### PR TITLE
HMAC for entropy generation

### DIFF
--- a/helpers/entropyUtils.js
+++ b/helpers/entropyUtils.js
@@ -11,21 +11,72 @@ export const wordsToUint8Array = (words) => {
   throw new Error(`Invalid word count length specified. Got ${words} but expected 12, 18 or 24`)
 }
 
-export const coordinateToRandomUInt8 = (x, y) => {
-  const xMax = Math.floor(x) % 255
-  const yMax = Math.floor(y) % 255
-  const xRand = getRandomInt(xMax)
-  const yRand = getRandomInt(yMax)
-  const randUint8 = Math.floor((xRand + yRand) / 2)
-  return randUint8
+export const mouseMovementEntropy = (x, y) => {
+  // baseKey generation based on http://phrack.org/issues/59/15.html
+  const leastSignificantX = parseInt((x).toString(2).slice(-4) + (y).toString(2).slice(-4), 2)
+  const leastSignificantTime = parseInt(window.performance.now().toString(2).slice(-8), 2)
+  const res = leastSignificantX ^ leastSignificantTime
+  return res
 }
 
-export const uint8ArrayCoordinateRandomize = (array, x, y) => {
-  const copy = new Uint8Array(array)
-  const randomIndex = getRandomInt(array.length)
-  const randomUint8 = coordinateToRandomUInt8(x, y)
-  copy[randomIndex] = randomUint8
-  return copy
+export const getKeyMaterial = async (mouseMovemenntEntropy) => {
+  // Generate keyMaterial using PBKDF2 from low entropy input source. Used to derive a proper key later
+  // https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/importKey
+  // https://github.com/mdn/dom-examples/blob/master/web-crypto/derive-key/pbkdf2.js
+
+  const keyMaterial = await window.crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(mouseMovemenntEntropy),
+    { name: 'PBKDF2' },
+    false,
+    ['deriveBits', 'deriveKey']
+  )
+
+  return keyMaterial
+}
+
+const PBKDF2 = {
+  'name': 'PBKDF2',
+  'iterations': 100000,
+  'hash': 'SHA-256'
+}
+
+const HMAC = { 'name': 'HMAC', 'hash': 'SHA-256' }
+
+export const deriveKey = async (keyMaterial, salt) => {
+  // Derive PDKDF2 key from keyMaterial
+  // https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/deriveKey
+
+  const derivedKey = await window.crypto.subtle.deriveKey(
+    { ...PBKDF2, salt },
+    keyMaterial,
+    HMAC,
+    true,
+    [ 'sign', 'verify' ]
+  )
+
+  return derivedKey
+}
+
+export const mouseMovementToHmacEntropy = async (mouseMovementEntropy, previousHmacEntropy) => {
+  if (mouseMovementEntropy.length < 16) {
+    // not enough mouse entropy
+    console.log(mouseMovementEntropy)
+    return previousHmacEntropy
+  }
+
+  const len = previousHmacEntropy.length
+  const message = new Uint8Array(previousHmacEntropy)
+  const salt = window.crypto.getRandomValues(new Uint8Array(16))
+  const keyMaterial = await getKeyMaterial(mouseMovementEntropy)
+  const key = await deriveKey(keyMaterial, salt)
+  const signature = await window.crypto.subtle.sign(
+    'HMAC',
+    key,
+    message
+  )
+
+  return new Uint8Array(signature, 0, len)
 }
 
 export const getRandomInt = (max) => {


### PR DESCRIPTION
Tried implementing 2 things in the PR.

Initial idea is to use hmac-256 with mouse movement as key and previous entropy generated as message

```
eeeee is the data provided by CPRNG (256 bits); mm is some user input data, e.g. mouse movement
eeeee    mm
eeeee <- HMAC-Sha256(key=mm, message=eeeee)
```

Secondly, use http://phrack.org/issues/59/15.html as baseline on how to generate better entropy from mouse movements.

```
Steps:
- generate x, y
- concat last 4 bits of x and last 4 bits of y
- xor with last 8 bits of time in miliseconds
- append value (0 - 255) to array of gathered mouse entropy points 
- when 16 points have been gathered use mouse entropy points to generate raw PBKDF2-keyMaterial
- use keyMaterial + salt to derive another PBKDF2-key
-  use PBKDF2-key = key and previous hmac entropy as message and sign new message using HMAC-256
- return new Uint8Array from signature (usually first 16 / 32 elements)
```